### PR TITLE
fix #121 DataSourceProcessor and DataSinkProcessor default parallelism

### DIFF
--- a/streaming/src/main/scala/org/apache/gearpump/streaming/sink/DataSinkProcessor.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/sink/DataSinkProcessor.scala
@@ -39,7 +39,7 @@ import org.apache.gearpump.streaming.Processor
 object DataSinkProcessor {
   def apply(
       dataSink: DataSink,
-      parallelism: Int,
+      parallelism: Int = 1,
       description: String = "",
       taskConf: UserConfig = UserConfig.empty)(implicit system: ActorSystem)
     : Processor[DataSinkTask] = {

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/source/DataSourceProcessor.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/source/DataSourceProcessor.scala
@@ -39,7 +39,7 @@ import org.apache.gearpump.streaming.Processor
 object DataSourceProcessor {
   def apply(
       dataSource: DataSource,
-      parallelism: Int,
+      parallelism: Int = 1,
       description: String = "",
       taskConf: UserConfig = UserConfig.empty)(implicit system: ActorSystem)
     : Processor[DataSourceTask] = {


### PR DESCRIPTION
Set DataSourceProcessor and DataSinkProcessor's default parallelism value to 1. 

When user startup a processor could don't set parallelism .

[GEARPUMP-121](https://issues.apache.org/jira/browse/GEARPUMP-121)