### PR TITLE
fix GEARPUMP-141 , remove useless method

### DIFF
--- a/external/hbase/src/main/scala/io/gearpump/external/hbase/HBaseSink.scala
+++ b/external/hbase/src/main/scala/io/gearpump/external/hbase/HBaseSink.scala
@@ -85,18 +85,6 @@ class HBaseSink(
     connection.close()
     table.close()
   }
-
-  private def writeObject(out: ObjectOutputStream): Unit = {
-    out.defaultWriteObject()
-    configuration.write(out)
-  }
-
-  private def readObject(in: ObjectInputStream): Unit = {
-    in.defaultReadObject()
-    val clientConf = new Configuration(false)
-    clientConf.readFields(in)
-    configuration = HBaseConfiguration.create(clientConf)
-  }
 }
 
 object HBaseSink {


### PR DESCRIPTION
[GEARPUMP-141](https://issues.apache.org/jira/browse/GEARPUMP-141)  

In external-hbase module , writeObject and readObject seems never used . We can remove this methods .