### PR TITLE
fix GEARPUMP-83, show application pending on worker down

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
@@ -162,6 +162,12 @@ trait AppMasterRegisterData
 object AppMasterToMaster {
 
   /**
+   * Activate the AppMaster when an application is ready to run.
+   * @param appId application id
+   */
+  case class ActivateAppMaster(appId: Int)
+  
+  /**
    * Register an AppMaster by providing a ActorRef, and registerData
    * @param registerData The registerData is provided by Master when starting the app master.
    *                     App master should return the registerData back to master.
@@ -246,10 +252,14 @@ object MasterToAppMaster {
   /** Master confirm reception of RegisterAppMaster message */
   case class AppMasterRegistered(appId: Int)
 
+  /** Master confirm reception of ActivateAppMaster message */
+  case class AppMasterActivated(appId: Int)
+
   /** Shutdown the application job */
   case object ShutdownAppMaster
 
   type AppMasterStatus = String
+  val AppMasterPending: AppMasterStatus = "pending"
   val AppMasterActive: AppMasterStatus = "active"
   val AppMasterInActive: AppMasterStatus = "inactive"
   val AppMasterNonExist: AppMasterStatus = "nonexist"

--- a/core/src/main/scala/org/apache/gearpump/cluster/appmaster/MasterConnectionKeeper.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/appmaster/MasterConnectionKeeper.scala
@@ -46,7 +46,6 @@ class MasterConnectionKeeper(
   import context.dispatcher
 
   private val LOG = LogUtil.getLogger(getClass)
-  private var master: ActorRef = null
 
   // Subscribe self to masterProxy,
   masterProxy ! WatchMaster(self)
@@ -72,7 +71,7 @@ class MasterConnectionKeeper(
 
   def masterLivenessListener: Receive = {
     case MasterRestarted =>
-      LOG.info("Master restarted, re-registering appmaster....")
+      LOG.info("Master restarted, re-registering AppMaster....")
       context.become(waitMasterToConfirm(registerAppMaster))
     case MasterStopped =>
       LOG.info("Master is dead, killing this AppMaster....")

--- a/daemon/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
+++ b/daemon/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
@@ -187,8 +187,9 @@ private[cluster] class Master extends Actor with Stash {
     case request: RequestResource =>
       scheduler forward request
     case registerAppMaster: RegisterAppMaster =>
-      // Forward to appManager
       appManager forward registerAppMaster
+    case activateAppMaster: ActivateAppMaster =>
+      appManager forward activateAppMaster
     case save: SaveAppData =>
       appManager forward save
     case get: GetAppData =>

--- a/daemon/src/test/scala/org/apache/gearpump/cluster/master/AppManagerSpec.scala
+++ b/daemon/src/test/scala/org/apache/gearpump/cluster/master/AppManagerSpec.scala
@@ -52,20 +52,23 @@ class AppManagerSpec extends FlatSpec with Matchers with BeforeAndAfterEach with
     appManager = getActorSystem.actorOf(Props(new AppManager(kvService.ref,
       new DummyAppMasterLauncherFactory(appLauncher))))
     kvService.expectMsgType[GetKV]
-    kvService.reply(GetKVSuccess(MASTER_STATE, MasterState(0, Map.empty, Map.empty)))
+    kvService.reply(GetKVSuccess(MASTER_STATE, MasterState(0, Map.empty, Set.empty, Set.empty)))
   }
 
   override def afterEach(): Unit = {
     shutdownActorSystem()
   }
 
-  "AppManager" should "handle appmaster message correctly" in {
+  "AppManager" should "handle AppMaster message correctly" in {
     val appMaster = TestProbe()(getActorSystem)
-    val worker = TestProbe()(getActorSystem)
+    val appId = 1
 
-    val register = RegisterAppMaster(appMaster.ref, AppMasterRuntimeInfo(0, "appName"))
+    val register = RegisterAppMaster(appMaster.ref, AppMasterRuntimeInfo(appId, "appName"))
     appMaster.send(appManager, register)
     appMaster.expectMsgType[AppMasterRegistered]
+
+    appMaster.send(appManager, ActivateAppMaster(appId))
+    appMaster.expectMsgType[AppMasterActivated]
   }
 
   "DataStoreService" should "support Put and Get" in {

--- a/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/RestServiceSpec.scala
+++ b/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/RestServiceSpec.scala
@@ -162,7 +162,7 @@ class RestServiceSpec extends TestSpecBase {
       killAppAndVerify(appId)
     }
 
-    "should fail when attempting to kill a stopped application" in {
+    "fail when attempting to kill a stopped application" in {
       // setup
       val appId = restClient.getNextAvailableAppId()
       val submissionSucess = restClient.submitApp(wordCountJar, cluster.getWorkerHosts.length)
@@ -175,7 +175,7 @@ class RestServiceSpec extends TestSpecBase {
       success shouldBe false
     }
 
-    "should fail when attempting to kill a non-exist application" in {
+    "fail when attempting to kill a non-exist application" in {
       // setup
       val freeAppId = restClient.listApps().length + 1
 
@@ -342,6 +342,8 @@ class RestServiceSpec extends TestSpecBase {
       val killedApp = restClient.queryApp(originAppId)
       killedApp.appId shouldEqual originAppId
       killedApp.status shouldEqual MasterToAppMaster.AppMasterInActive
+      val newAppId = originAppId + 1
+      expectAppIsRunning(newAppId, wordCountName)
       val runningApps = restClient.listRunningApps()
       runningApps.length shouldEqual 1
       val newAppDetail = restClient.queryStreamingAppDetail(runningApps.head.appId)

--- a/integrationtest/core/src/main/scala/org/apache/gearpump/integrationtest/minicluster/RestClient.scala
+++ b/integrationtest/core/src/main/scala/org/apache/gearpump/integrationtest/minicluster/RestClient.scala
@@ -86,6 +86,11 @@ class RestClient(host: String, port: Int) {
     decodeAs[AppMastersData](resp).appMasters.toArray
   }
 
+  def listPendingOrRunningApps(): Array[AppMasterData] = {
+    listApps().filter(app => app.status == MasterToAppMaster.AppMasterActive
+      || app.status == MasterToAppMaster.AppMasterPending)
+  }
+
   def listRunningApps(): Array[AppMasterData] = {
     listApps().filter(_.status == MasterToAppMaster.AppMasterActive)
   }
@@ -96,7 +101,7 @@ class RestClient(host: String, port: Int) {
 
   def submitApp(jar: String, executorNum: Int, args: String = "", config: String = "")
     : Boolean = try {
-    var endpoint = "master/submitapp"
+    val endpoint = "master/submitapp"
 
     var options = Seq(s"jar=@$jar")
     if (config.length > 0) {

--- a/services/dashboard/services/models/models.js
+++ b/services/dashboard/services/models/models.js
@@ -138,6 +138,7 @@ angular.module('org.apache.gearpump.models', [])
           return angular.merge(obj, {
             // extra properties
             isRunning: obj.status === 'active',
+            isKilled: obj.status === 'inactive',
             akkaAddr: decoder._akkaAddr(obj.appMasterPath),
             // extra methods
             pageUrl: locator.app(obj.appId, obj.type),

--- a/services/dashboard/views/apps/apps.js
+++ b/services/dashboard/views/apps/apps.js
@@ -67,7 +67,8 @@ angular.module('dashboard')
           $stb.datetime('Start Time').key('startTime').canSort().styleClass('col-md-1 hidden-sm hidden-xs').done(),
           $stb.datetime('Stop Time').key('stopTime').canSort().styleClass('col-md-1 hidden-sm hidden-xs').done(),
           $stb.text('User').key('user').canSort().styleClass('col-md-2').done(),
-          // group 3/3 (3-col)
+          // group 3/3 (4-col)
+          $stb.text('Status').key('status').canSort().styleClass('col-md-1 hidden-sm hidden-xs').done(),
           $stb.button('Actions').key(['view', 'config', 'kill', 'restart']).styleClass('col-md-3').done()
         ],
         rows: null
@@ -86,6 +87,7 @@ angular.module('dashboard')
               submissionTime: app.submissionTime,
               startTime: app.startTime,
               stopTime: app.finishTime || '-',
+              status: app.status,
               view: {
                 href: app.pageUrl,
                 text: 'Details',
@@ -94,7 +96,7 @@ angular.module('dashboard')
               },
               config: {href: app.configLink, target: '_blank', text: 'Config', class: 'btn-xs'},
               kill: {
-                text: 'Kill', class: 'btn-xs', disabled: !app.isRunning,
+                text: 'Kill', class: 'btn-xs', disabled: app.isKilled,
                 click: function () {
                   $dialogs.confirm('Are you sure to kill this application?', function () {
                     app.terminate();

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
@@ -120,6 +120,10 @@ private[appmaster] class TaskManager(
     dagManager ! GetLatestDAG
     LOG.info(s"goto state ApplicationReady(dag = ${state.dag.version})...")
 
+    if (state.dag.version >= 0) {
+      appMaster ! ApplicationReady
+    }
+
     val recoverRegistry = new TaskRegistry(expectedTasks = state.dag.tasks,
       deadTasks = state.taskRegistry.deadTasks)
 
@@ -271,7 +275,7 @@ private[appmaster] class TaskManager(
       }
 
     case RegisterTask(taskId, executorId, host) =>
-      val client = sender
+      val client = sender()
       val register = state.taskRegistry
       val status = register.registerTask(taskId, TaskLocation(executorId, host))
       if (status == Accept) {
@@ -399,6 +403,8 @@ private[appmaster] object TaskManager {
   case object GetTaskList
 
   case class TaskList(tasks: Map[TaskId, ExecutorId])
+
+  case object ApplicationReady
 
   case class FailedToRecover(errorMsg: String)
 


### PR DESCRIPTION
Changes include:

1. add `activeAppMasters` set to `masterState` and `deadAppMasters` is changed to set of appIds. Now all existent applications will be in `appMasterRegistry` and in **pending** status by default. Those in `activeAppMasters` will have **active** status and `deadAppMasters` **inactive** status.
2. add a status column to the "apps" page on the dashboard. status will be one of pending, active and inactive. 
3. Internally, `TaskManager` will send an `ApplicationReady` message to `AppMaster` on ApplicationReady state(with DAG version larger than -1). In turn, `AppMaster` will send an `ActivateApplication(appId)` message to `Master`(forwarded to `AppManager`). Then the `appId` is added to `activeAppMasters`. It is removed from `activeAppMasters` either when an application is killed or recovered. 
4. add UTs and fix a bunch of warnings (typos, suspicious shadowing, etc)
5. fix integration test
6. allow to kill pending applications


