### PR TITLE
fix GEARPUMP-32, introduce source watermark

### DIFF
--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaSourceSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaSourceSpec.scala
@@ -25,8 +25,7 @@ import kafka.common.TopicAndPartition
 import org.apache.gearpump.streaming.MockUtil
 import org.apache.gearpump.streaming.kafka.lib.source.consumer.FetchThread.FetchThreadFactory
 import org.apache.gearpump.streaming.kafka.lib.source.grouper.PartitionGrouper
-import org.apache.gearpump.streaming.kafka.lib.util.KafkaClient
-import KafkaClient.KafkaClientFactory
+import org.apache.gearpump.streaming.kafka.lib.util.KafkaClient.KafkaClientFactory
 import org.apache.gearpump.streaming.kafka.lib.source.consumer.{KafkaMessage, FetchThread}
 import org.apache.gearpump.streaming.kafka.lib.util.KafkaClient
 import org.apache.gearpump.streaming.kafka.util.KafkaConfig
@@ -173,7 +172,7 @@ class KafkaSourceSpec extends PropSpec with PropertyChecks with Matchers with Mo
           when(fetchThread.poll).thenReturn(Option(kafkaMsg))
           val message = Message(kafkaMsg.msg, kafkaMsg.offset)
           when(messageDecoder.fromBytes(kafkaMsg.key.get, kafkaMsg.msg)).thenReturn(message)
-          when(timestampFilter.filter(message, 0)).thenReturn(Some(message))
+          when(timestampFilter.filter(any[Message], anyLong())).thenReturn(Some(message))
           source.read() shouldBe Message(kafkaMsg.msg, kafkaMsg.offset)
           verify(checkpointStores(kafkaMsg.topicAndPartition)).persist(
             kafkaMsg.offset, Injection[Long, Array[Byte]](kafkaMsg.offset))

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/AppMaster.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/AppMaster.scala
@@ -145,7 +145,7 @@ class AppMaster(appContext: AppMasterContext, app: AppDescription) extends Appli
   /** Handles messages from Tasks */
   def taskMessageHandler: Receive = {
     case clock: ClockEvent =>
-      taskManager.foreach(_ forward clock)
+      clockService.foreach(_ forward clock)
     case register: RegisterTask =>
       taskManager.foreach(_ forward register)
     case unRegister: UnRegisterTask =>
@@ -159,15 +159,11 @@ class AppMaster(appContext: AppMasterContext, app: AppDescription) extends Appli
       taskManager.foreach(_ forward messageLoss)
     case lookupTask: LookupTaskActorRef =>
       taskManager.foreach(_ forward lookupTask)
-    case checkpoint: ReportCheckpointClock =>
-      clockService.foreach(_ forward checkpoint)
     case GetDAG =>
       val task = sender
       getDAG.foreach {
         dag => task ! dag
       }
-    case GetCheckpointClock =>
-      clockService.foreach(_ forward GetCheckpointClock)
   }
 
   /** Handles messages from Executors */

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
@@ -72,7 +72,6 @@ private[appmaster] class TaskManager(
   extends Actor {
 
   private val LOG: Logger = LogUtil.getLogger(getClass, app = appId)
-  private val systemConfig = context.system.settings.config
 
   private val ids = new SessionIdFactory()
 
@@ -96,8 +95,6 @@ private[appmaster] class TaskManager(
   def receive: Receive = applicationReady(DagReadyState.empty)
 
   private def onClientQuery(taskRegistry: TaskRegistry): Receive = {
-    case clock: ClockEvent =>
-      clockService forward clock
     case GetTaskList =>
       sender ! TaskList(taskRegistry.getTaskExecutorMap)
     case LookupTaskActorRef(taskId) =>

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/dsl/StreamApp.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/dsl/StreamApp.scala
@@ -108,9 +108,11 @@ object StreamApp {
 /** A test message source which generated message sequence repeatedly. */
 class CollectionDataSource[T](seq: Seq[T]) extends DataSource {
   private lazy val iterator: Iterator[T] = seq.iterator
+  private var watermark: TimeStamp = 0L
 
   override def read(): Message = {
     if (iterator.hasNext) {
+      watermark = System.currentTimeMillis()
       Message(iterator.next())
     } else {
       null
@@ -120,4 +122,6 @@ class CollectionDataSource[T](seq: Seq[T]) extends DataSource {
   override def close(): Unit = {}
 
   override def open(context: TaskContext, startTime: TimeStamp): Unit = {}
+
+  override def getWatermark: TimeStamp = watermark
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/source/DataSource.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/source/DataSource.scala
@@ -19,7 +19,7 @@
 package org.apache.gearpump.streaming.source
 
 import org.apache.gearpump.streaming.task.TaskContext
-import org.apache.gearpump.Message
+import org.apache.gearpump.{TimeStamp, Message}
 
 import scala.util.Random
 
@@ -67,4 +67,11 @@ trait DataSource extends java.io.Serializable {
    * invoked in onStop() method of [[org.apache.gearpump.streaming.source.DataSourceTask]]
    */
   def close(): Unit
+
+  /**
+   * Returns a watermark
+   * no timestamp earlier than the watermark
+   * should enter the system
+   */
+  def getWatermark: TimeStamp
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/source/DefaultTimeStampFilter.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/source/DefaultTimeStampFilter.scala
@@ -26,6 +26,6 @@ import org.apache.gearpump.{Message, TimeStamp}
  */
 class DefaultTimeStampFilter extends TimeStampFilter {
   override def filter(msg: Message, predicate: TimeStamp): Option[Message] = {
-    Option(msg).find(_.timestamp >= predicate)
+    Option(msg).filter(_.timestamp >= predicate)
   }
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskControlMessage.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskControlMessage.scala
@@ -48,13 +48,15 @@ object GetLatestMinClock extends ClockEvent
 
 case class GetUpstreamMinClock(taskId: TaskId) extends ClockEvent
 
+case class ReportCheckpointClock(taskId: TaskId, clock: TimeStamp) extends ClockEvent
+
+case object GetCheckpointClock extends ClockEvent
+
+case class UpdateWatermark(taskId: TaskId, time: TimeStamp) extends ClockEvent
+
 case class UpstreamMinClock(latestMinClock: TimeStamp)
 
 case class LatestMinClock(clock: TimeStamp)
-
-case class ReportCheckpointClock(taskId: TaskId, clock: TimeStamp)
-
-case object GetCheckpointClock
 
 case class CheckpointClock(clock: Option[TimeStamp])
 


### PR DESCRIPTION
This PR introduces source watermark such that 

1. messages with timestamps earlier than watermark could be filtered out at source.
2. minclock of source processor will be bounded by watemark