### PR TITLE
fix GEARPUMP-155, integration test failure

### DIFF
--- a/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/CommandLineSpec.scala
+++ b/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/CommandLineSpec.scala
@@ -18,7 +18,7 @@
 package org.apache.gearpump.integrationtest.checklist
 
 import org.apache.gearpump.cluster.MasterToAppMaster
-import org.apache.gearpump.integrationtest.TestSpecBase
+import org.apache.gearpump.integrationtest.{Util, TestSpecBase}
 
 /**
  * The test spec checks the command-line usage
@@ -86,7 +86,7 @@ class CommandLineSpec extends TestSpecBase {
       success shouldBe false
     }
 
-    "the EmbededCluster can be used as embedded cluster in process" in {
+    "the EmbeddedCluster can be used as embedded cluster in process" in {
       // setup
       val args = "-debug true -sleep 10"
       val appId = expectSubmitAppSuccess(wordCountJar, args)
@@ -125,9 +125,11 @@ class CommandLineSpec extends TestSpecBase {
   }
 
   private def expectAppIsRunningByParsingOutput(appId: Int, expectedName: String): Unit = {
-    val actual = commandLineClient.queryApp(appId)
-    actual should include(s"application: $appId, ")
-    actual should include(s"name: $expectedName, ")
-    actual should include(s"status: ${MasterToAppMaster.AppMasterActive}")
+    Util.retryUntil(() => {
+      val actual = commandLineClient.queryApp(appId)
+      actual.contains(s"application: $appId, ") &&
+        actual.contains(s"name: $expectedName, ") &&
+        actual.contains(s"status: ${MasterToAppMaster.AppMasterActive}")
+    }, "application is running")
   }
 }

--- a/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/ExampleSpec.scala
+++ b/integrationtest/core/src/it/scala/org/apache/gearpump/integrationtest/checklist/ExampleSpec.scala
@@ -45,7 +45,7 @@ class ExampleSpec extends TestSpecBase {
         "-command", "hostname"
       )
 
-      val expectedHostNames = cluster.getWorkerHosts.map(Docker.getHostName(_))
+      val expectedHostNames = cluster.getWorkerHosts.map(Docker.getHostName)
 
       def verify(): Boolean = {
         val workerNum = cluster.getWorkerHosts.length

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/AppMaster.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/AppMaster.scala
@@ -36,7 +36,7 @@ import org.apache.gearpump.streaming._
 import org.apache.gearpump.streaming.appmaster.AppMaster._
 import org.apache.gearpump.streaming.appmaster.DagManager.{GetLatestDAG, LatestDAG, ReplaceProcessor}
 import org.apache.gearpump.streaming.appmaster.ExecutorManager.{ExecutorInfo, GetExecutorInfo}
-import org.apache.gearpump.streaming.appmaster.TaskManager.{ApplicationReady, FailedToRecover, GetTaskList, TaskList}
+import org.apache.gearpump.streaming.appmaster.TaskManager.{ApplicationReady, GetTaskList, TaskList, FailedToRecover}
 import org.apache.gearpump.streaming.executor.Executor.{ExecutorConfig, ExecutorSummary, GetExecutorSummary, QueryExecutorConfig}
 import org.apache.gearpump.streaming.storage.InMemoryAppStoreOnMaster
 import org.apache.gearpump.streaming.task._
@@ -286,8 +286,8 @@ class AppMaster(appContext: AppMasterContext, app: AppDescription) extends Appli
   def ready: Receive = {
     case ApplicationReady =>
       masterProxy ! ActivateAppMaster(appId)
-    case AppMasterActivated(appId) =>
-      LOG.info(s"AppMaster for app$appId is activated")
+    case AppMasterActivated(id) =>
+      LOG.info(s"AppMaster for app$id is activated")
   }
 
   /** Error handling */

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskManagerSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskManagerSpec.scala
@@ -116,7 +116,7 @@ class TaskManagerSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     executorManager.expectMsg(BroadCast(RestartTasks(dagVersion)))
   }
 
-  import org.apache.gearpump.streaming.appmaster.TaskManager.TaskChangeRegistry
+  import TaskManager.TaskChangeRegistry
   "TaskChangeRegistry" should "track all modified task registration" in {
     val tasks = List(TaskId(0, 0), TaskId(0, 1))
     val registry = new TaskChangeRegistry(tasks)


### PR DESCRIPTION
Changes include:

1. fix integration test
2. `DistShellAppMaster` and `DistServiceAppMaster` send `ActivateAppMaster(appId)`  message to master when all the executor systems have been launched
3. fix warning 