### PR TITLE
[GEARPUMP-172] Add timed interval rotation on HDFS module

### DIFF
--- a/external/hadoopfs/src/main/scala/org/apache/gearpump/streaming/hadoop/lib/rotation/TimedIntervalRotation.scala
+++ b/external/hadoopfs/src/main/scala/org/apache/gearpump/streaming/hadoop/lib/rotation/TimedIntervalRotation.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gearpump.streaming.hadoop.lib.rotation
+
+import org.apache.gearpump.TimeStamp
+
+class TimedIntervalRotation(timeInterval: Long) extends Rotation {
+
+  private var currentTimestamp = System.currentTimeMillis()
+
+  override def mark(timestamp: TimeStamp, offset: TimeStamp): Unit = {
+    currentTimestamp = timestamp
+  }
+
+  override def rotate(): Unit = {
+    currentTimestamp = System.currentTimeMillis()
+  }
+
+  override def shouldRotate: Boolean = {
+    (System.currentTimeMillis() - currentTimestamp) > timeInterval
+  }
+}


### PR DESCRIPTION
[GEARPUMP-172](https://issues.apache.org/jira/browse/GEARPUMP-172)

The time interval rotation will rolling out a new file when time interval get the limit