### PR TITLE
[GEARPUMP-228] Message's timestamp should be current time stamp

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/Message.scala
+++ b/core/src/main/scala/org/apache/gearpump/Message.scala
@@ -25,8 +25,9 @@ package org.apache.gearpump
  * message's timestamp.
  * @param msg Accept any type except Null, Nothing and Unit
  */
-case class Message(msg: Any, timestamp: TimeStamp = Message.noTimeStamp)
+case class Message(msg: Any, timestamp: TimeStamp = Message.currentTimeStamp)
 
 object Message {
   val noTimeStamp: TimeStamp = 0L
+  val currentTimeStamp: TimeStamp = System.currentTimeMillis()
 }


### PR DESCRIPTION
[GEARPUMP-228 Message's timestamp should be current time stamp](https://issues.apache.org/jira/browse/GEARPUMP-228)

Using System.currentTimeMillis() as Message's default timestamp maybe better than 0.
