### PR TITLE
[GEARPUMP-328] FetchThread fetchSleepMS from Int to Long

### DIFF
--- a/external/kafka/src/main/java/org/apache/gearpump/streaming/kafka/util/KafkaConfig.java
+++ b/external/kafka/src/main/java/org/apache/gearpump/streaming/kafka/util/KafkaConfig.java
@@ -142,7 +142,7 @@ public class KafkaConfig extends AbstractConfig implements Serializable {
             ConfigDef.Importance.LOW,
             FETCH_THRESHOLD_DOC)
         .define(FETCH_SLEEP_MS_CONFIG,
-            ConfigDef.Type.INT,
+            ConfigDef.Type.LONG,
             100,
             ConfigDef.Range.atLeast(0),
             ConfigDef.Importance.LOW,

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/source/consumer/FetchThread.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/source/consumer/FetchThread.scala
@@ -36,7 +36,7 @@ object FetchThread {
   class FetchThreadFactory extends java.io.Serializable {
     def getFetchThread(config: KafkaConfig, client: KafkaClient): FetchThread = {
       val fetchThreshold = config.getInt(KafkaConfig.FETCH_THRESHOLD_CONFIG)
-      val fetchSleepMS = config.getInt(KafkaConfig.FETCH_SLEEP_MS_CONFIG)
+      val fetchSleepMS = config.getLong(KafkaConfig.FETCH_SLEEP_MS_CONFIG)
       val startOffsetTime = config.getLong(KafkaConfig.CONSUMER_START_OFFSET_CONFIG)
       FetchThread(fetchThreshold, fetchSleepMS, startOffsetTime, client)
     }


### PR DESCRIPTION
currently *KafkaConfig.FETCH_SLEEP_MS_CONFIG* is a INT parameter , move it into a LONG parameter is better .

