### PR TITLE
[GEARPUMP-351] Support executor number in submit

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/cluster/client/ClientContext.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/client/ClientContext.scala
@@ -80,6 +80,10 @@ class ClientContext(config: Config, sys: ActorSystem, _master: ActorRef) {
     submit(app, System.getProperty(GEARPUMP_APP_JAR))
   }
 
+  def submit(app: Application, executorNum: Int): RunningApplication = {
+    submit(app, System.getProperty(GEARPUMP_APP_JAR), executorNum)
+  }
+
   def submit(app: Application, jar: String): RunningApplication = {
     submit(app, jar, getExecutorNum)
   }


### PR DESCRIPTION
When `ClientContext` submit application to cluster and must add a argument executors to specifies the executor number use to running job , otherwise it will running in a JVM process. 

We should support executor number in program API .