### PR TITLE
Use alpine-based image for gearpump-runner

### DIFF
--- a/integrationtest/docker/README.md
+++ b/integrationtest/docker/README.md
@@ -6,7 +6,6 @@ These include:
  * [The standalone single node Kafka cluster with Zookeeper](kafka)
  * [The Hadoop image](hadoop)
  * [The Gearpump Cluster Launcher and Storm Client](gearpump)
- * [Java 8 JRE image](java)
 
 
 We decided to fork spotify/kafka image, because the project does not maintain proper tagging. 
@@ -15,9 +14,5 @@ For now our tests focus on Kafka 0.8.x, and the project does not support this ve
 Hadoop docker image (https://hub.docker.com/r/sequenceiq/hadoop-docker/) is well maintained. 
 We rely on version 2.6.0 and we feel there is no need to duplicate it.
 
-Gearpump Cluster Launcher  helps developer to setup/test a local Gearpump cluster quickly. 
+Gearpump Cluster Launcher helps developer to setup/test a local Gearpump cluster quickly. 
 The image is based on a minimal JRE8 environment with Python support.
-
-We used to base Gearpump Cluster Launcher on errordeveloper/oracle-jre image but it stuck on version 8u66-b17 and doesn't support tagging.
-We also probably hit a Java bug (http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8133205) that requires newer version of JRE.
-This is experimental version of Java image that we will use until we switch to some "official" image.

--- a/integrationtest/docker/gearpump/Dockerfile
+++ b/integrationtest/docker/gearpump/Dockerfile
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 # The base image contains JRE8
-FROM grubykarol/jre:8u121b13_server
+FROM openjdk:8u131-jre-alpine
 
-# Add Python Support
-RUN opkg-install python
+# Install python
+RUN apk add --no-cache python && \
+    python -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip install --upgrade pip setuptools && \
+    rm -r /root/.cache
 
 # Create SUT home, files will be mounted at runtime.
 ENV SUT_HOME=/opt/gearpump

--- a/integrationtest/docker/gearpump/README.md
+++ b/integrationtest/docker/gearpump/README.md
@@ -23,6 +23,6 @@ docker run -d \
  grubykarol/gearpump-launcher \
  worker
 
-docker exec master0 gear info
-docker exec master0 gear app -jar /path/to/userapp.jar [mainclass] [args]
+docker exec master0 bin/gear info
+docker exec master0 bin/gear app -jar /path/to/userapp.jar [mainclass] [args]
 ```


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the commit message is formatted like:
   `[GEARPUMP-<Jira issue #>] Meaningful description of pull request` 
 - [ ] Make sure tests pass via `sbt clean test`.
 - [ ] Make sure old documentation affected by the pull request has been updated and new documentation added for new functionality. 

To verify:
1. build the image (`docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy -t gearpump/gearpump-launcher integrationtest/docker/gearpump/
`)
2. run the master (`docker run -d -h master0 -v /etc/localtime:/etc/localtime:ro -p 8090:8090 -e JAVA_OPTS=-Dgearpump.cluster.masters.0=master0:3000 -v $GEARPUMP_HOME:/opt/gearpump -v /tmp/gearpump:/var/log/gearpump --name master0 gearpump/gearpump-launcher master -ip master0 -port 3000` - please, mind it tries to use the port 8090)
3. run the worker (`docker run -d -h worker0 -v /etc/localtime:/etc/localtime:ro -e JAVA_OPTS=-Dgearpump.cluster.masters.0=master0:3000 -v $GEARPUMP_HOME:/opt/gearpump -v /tmp/gearpump:/var/log/gearpump --link master0 --name worker0 gearpump/gearpump-launcher worker`)
4. verify it works (`docker logs master0`, `docker logs worker0`, open localhost:8090 in the browser)